### PR TITLE
Hide unpublished posts.

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,10 @@ layout: default
 
   <div class="posts">
     {% for post in paginator.posts %}
+    {% if post.publish == false %}
+      {% continue %}
+    {% endif %}
     <div class="post-teaser">
-
       <header>
         <h1>
           <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>


### PR DESCRIPTION
`publish: false`로 정의된 포스트들에 대해서는 메인 페이지에서 렌더링하지 않습니다.