### PR TITLE
블로그의 여백과 폰트 크기를 변경합니다.

### DIFF
--- a/_sass/base/_global.scss
+++ b/_sass/base/_global.scss
@@ -28,16 +28,16 @@ h1, h2, h3, h4, h5, h6 {
   }
 }
 h1 {
-  font-size: 2.5em;
+  font-size: 1.8em;
 }
 h2 {
-  font-size: 2em;
-}
-h3 {
   font-size: 1.5em;
 }
+h3 {
+  font-size: 1.2em;
+}
 h4 {
-  font-size: 1.15em;
+  font-size: $font-size;
 }
 blockquote {
     border-left: 2px solid;

--- a/_sass/base/_utility.scss
+++ b/_sass/base/_utility.scss
@@ -8,7 +8,7 @@
 %padding-regular {
   padding: $padding-small $padding-large;
   @media (max-width: 1000px) { 
-    padding: $padding-small * 1.5 $padding-large / 1.6;
+    padding: $padding-small $padding-small;
   }
 }
 %link-hover {

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -1,6 +1,6 @@
 // Typography
 $font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif;
-$font-size: 1.25em;
+$font-size: 1.15em;
 
 // Padding
 $padding-large: 20%;

--- a/_sass/layouts/_posts.scss
+++ b/_sass/layouts/_posts.scss
@@ -18,9 +18,8 @@ article {
   }
 }
 header {
-  h1 {
-    margin: 0;
-  }
+  h1 { margin: 0; }
+  h2 { margin: 0; }
   .meta {
     color: rgba($text-color, .5);
     font-size: 0.9em;

--- a/index.html
+++ b/index.html
@@ -15,9 +15,9 @@ layout: default
     {% endif %}
     <div class="post-teaser">
       <header>
-        <h1>
+        <h2>
           <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-        </h1>
+        </h2>
 
         <p class="meta">
           {{ post.date | date: "%Y년 %-m월 %-d일" }} -


### PR DESCRIPTION
넓은 화면에선 문제없지만 모바일 기기에서는 여백이 너무 커서 글이 세로로 길어지는 문제가 있어서 변경합니다.

- 기본 폰트 크기 변경: 1.25em (20px)-> 1.15em(18px)
- `h1` ~ `h4`의 폰트 크기를 줄입니다
- 안쪽 여백 크기 변경