### PR TITLE
전체적인 폰트 수정

### DIFF
--- a/_sass/base/_global.scss
+++ b/_sass/base/_global.scss
@@ -19,6 +19,7 @@ body {
   font-family: $font-family;
   font-size: $font-size;
   word-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
 }
 h1, h2, h3, h4, h5, h6 {
   line-height: 1.3;
@@ -32,9 +33,12 @@ h1 {
 }
 h2 {
   font-size: 1.5em;
+  padding-bottom: 0.3em;
 }
 h3 {
   font-size: 1.2em;
+  margin-top: 1em;
+  line-height: 1.43;
 }
 h4 {
   font-size: $font-size;

--- a/_sass/base/_utility.scss
+++ b/_sass/base/_utility.scss
@@ -21,7 +21,7 @@
   border: 1px solid;
   display: inline-block;
   margin: 1em 0;
-  padding: 0.5em 0.75em;
+  padding: 0.75em 2em;
 }
 a.button:hover {
   background: $link-color;

--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -1,5 +1,5 @@
 // Typography
-$font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif;
+$font-family: 'Apple SD Gothic Neo', Helvetica, Arial, sans-serif;
 $font-size: 1.15em;
 
 // Padding
@@ -13,12 +13,12 @@ $background-color: #fff;
 $border-color: rgba(0, 0, 0, 0.1); // rgba recommended if using feature images
 
 // Typography colours
-$text-color: #383838;
-$link-color: #1ABC9C;
+$text-color: #404040;
+$link-color: #4183c4;
 $selection-color: #D4D4D4; // visible when highlighting text
 
 // Header colours
-$header-link-color: #383838;
+$header-link-color: #404040;
 
 // Feature image for articles
 $feature-image-text-color: #fff;

--- a/_sass/layouts/_posts.scss
+++ b/_sass/layouts/_posts.scss
@@ -16,6 +16,9 @@ article {
   .footnotes {
     font-size: 0.9em;
   }
+  h2 {
+    padding-top: 1em;
+  }
 }
 header {
   h1 { margin: 0; }


### PR DESCRIPTION
- Font Family를 산돌고딕으로 변경
- `-webkit-font-smooth`를 `antialiased`로 설정
- 본문 헤딩 여백 살짝 조절
- 링크 강조색을 무난한 색으로 변경

- [Before 보기](https://cloud.githubusercontent.com/assets/931655/8149786/cc0ee760-130b-11e5-87df-1f4253eb5c77.png)
- [After 보기](https://cloud.githubusercontent.com/assets/931655/8149787/cc122286-130b-11e5-9f40-4d3239fd5c9d.png)
