### PR TITLE
Standard facebook like button too long

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,8 +21,10 @@ layout: default
   <center>
     <a class="button" href="{{ site.url }}">목록으로 돌아가기</a><br />
   </center>
+
   <div class="fb-like" data-href="{{ site.url }}{{ page.url }}"
-       data-layout="standard" data-action="like" data-show-faces="true" data-share="true"></div>
+       data-layout="button_count" data-action="like" data-show-faces="false" data-share="true">
+  </div>
 
   <div id="fb-root"></div>
   <script>(function(d, s, id) {


### PR DESCRIPTION
모바일 웹에서 가로 스크롤이 생기기 때문에 변경합니다.

<img width="447" alt="2015-07-08 11 21 01" src="https://cloud.githubusercontent.com/assets/1697463/8561639/7622fc5a-2563-11e5-9a74-8c041e10b172.png">
