### PR TITLE
테이블 튀어나온 문제 수정

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -164,7 +164,7 @@
 .jobs {
   width: 100%;
   text-align: center;
-  margin: 50px;
+  margin: 30px 0 30px 0;
 }
 
 .jobs thead tr th {


### PR DESCRIPTION
테이블이 전체 레이아웃을 벗어나 옆으로 튀어나가 있었습니다. 마진을 조정하여 해결합니다.